### PR TITLE
Add minimal tests to ensure pypardiso works with scipy sparse arrays

### DIFF
--- a/tests/test_basic_solve.py
+++ b/tests/test_basic_solve.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+import scipy.sparse as sp
+
 from utils import create_test_A_b_rand, basic_solve
 from pypardiso.scipy_aliases import pypardiso_solver
 
@@ -12,4 +14,10 @@ def test_bvector_smoketest():
 
 def test_bmatrix_smoketest():
     A, b = create_test_A_b_rand(matrix=True)
+    basic_solve(A, b)
+
+
+def test_Aarray_smoketest():
+    A, b = create_test_A_b_rand()
+    A = sp.csr_array(A)
     basic_solve(A, b)

--- a/tests/test_input_b.py
+++ b/tests/test_input_b.py
@@ -16,7 +16,7 @@ def test_input_b_sparse():
     bsparse = sp.csr_matrix(b)
     with pytest.warns(SparseEfficiencyWarning):
         x = ps.solve(A, bsparse)
-        np.testing.assert_array_almost_equal(A*x, b)
+        np.testing.assert_array_almost_equal(A @ x, b)
 
 
 def test_input_b_shape():

--- a/tests/test_scipy_aliases.py
+++ b/tests/test_scipy_aliases.py
@@ -39,7 +39,7 @@ def test_basic_spsolve_sparray():
     np.testing.assert_array_almost_equal(xpp, xscipy)
 
 
-@pytest.mark.filterwarnings("ignore:splu requires CSC matrix format")
+@pytest.mark.filterwarnings("ignore:splu converted its input to CSC format")
 def test_basic_factorized():
     ps.remove_stored_factorization()
     ps.free_memory()

--- a/tests/test_scipy_aliases.py
+++ b/tests/test_scipy_aliases.py
@@ -29,6 +29,16 @@ def test_basic_spsolve_matrix():
     np.testing.assert_array_almost_equal(xpp, xscipy)
 
 
+def test_basic_spsolve_sparray():
+    ps.remove_stored_factorization()
+    ps.free_memory()
+    A, b = create_test_A_b_rand(matrix=True)
+    A = sp.csr_array(A)
+    xpp = spsolve(A, b)
+    xscipy = scipyspsolve(A, b)
+    np.testing.assert_array_almost_equal(xpp, xscipy)
+
+
 @pytest.mark.filterwarnings("ignore:splu requires CSC matrix format")
 def test_basic_factorized():
     ps.remove_stored_factorization()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,4 +53,4 @@ def create_test_A_b_rand(n=1000, density=0.05, matrix=False):
 
 def basic_solve(A, b):
     x = ps.solve(A, b)
-    np.testing.assert_array_almost_equal(A*x, b)
+    np.testing.assert_array_almost_equal(A @ x, b)


### PR DESCRIPTION
> This package is switching to an array interface, compatible with NumPy arrays, from the older matrix interface. We recommend that you use the array objects ([bsr_array](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.bsr_array.html#scipy.sparse.bsr_array), [coo_array](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.coo_array.html#scipy.sparse.coo_array), etc.) for all new work.

from https://docs.scipy.org/doc/scipy/reference/sparse.html#sparse-matrices-scipy-sparse

New tests are expected to fail until #67 is merged.