### PR TITLE
Update MKL pinning, latest releases are fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "mkl<2024",
+  "mkl!=2024.0",
   "numpy",
   "scipy"
 ]


### PR DESCRIPTION
Latest PyPI releases [`2024.1`](https://pypi.org/project/mkl/2024.1.0/) are fixed, however they are not available yet on conda-forge, so we explicitly exlude the problematic `2024.0` version instead of the previous pin to `<2024`

See also #58 