### PR TITLE
Invert pipeline success to detect future windows mkl fix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,10 +84,18 @@ jobs:
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
+        id: tests
+        continue-on-error: true
         shell: bash -l {0}
         run: |
           conda install pytest
           python -m pytest
+      - name: invert failure
+        if: ${{ steps.tests.outcome != 'success' && matrix.os == 'windows-latest' }}
+        run: exit 0
+      - name: invert success
+        if: ${{ steps.tests.outcome == 'success' && matrix.os == 'windows-latest' }}
+        run: exit 1
 
   pip-tests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
On conda-forge mkl is pinned to <2024 currently, but conda tests run with latest (currently broken) mkl releases

This PR inverts the pipeline success for windows conda tests. This has two benefits, a) canary pipeline "won't fail" every day, b) as soon as fixed mkl packages are released the pipeline will fail thereby notifying about required action to update mkl pins