### PR TITLE
Fix type mismatch for sparse arrays

### DIFF
--- a/pypardiso/pardiso_wrapper.py
+++ b/pypardiso/pardiso_wrapper.py
@@ -271,8 +271,8 @@ class PyPardisoSolver:
         c_float64_p = ctypes.POINTER(ctypes.c_double)
 
         # 1-based indexing
-        ia = A.indptr + 1
-        ja = A.indices + 1
+        ia = A.indptr.astype(np.int32) + 1
+        ja = A.indices.astype(np.int32) + 1
 
         self._mkl_pardiso(self.pt.ctypes.data_as(ctypes.POINTER(self._pt_type[0])),  # pt
                           ctypes.byref(ctypes.c_int32(1)),  # maxfct


### PR DESCRIPTION
The new `csr_array` stores their indices as `int64`. This fixes #77 by converting them to `int32` before calling Pardiso.

Note that in the long-run, we may want to verify the array size first and, if if conversion isn't feasible, invoke the pypardiso_64 interface.