### PR TITLE
[ENH] manually set iparm & support `overwrite_b` parameter

### DIFF
--- a/pypardiso/pardiso_wrapper.py
+++ b/pypardiso/pardiso_wrapper.py
@@ -145,20 +145,20 @@ class PyPardisoSolver:
         self._init_iparm() # manually setup iparm
 
     def _init_iparm(self):
-        # https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-c/2025-2/pardiso-iparm-parameter.html
-        self.iparm[0 ] = 1   # manually setting
-        self.iparm[1 ] = 103 # OMP version of fill-in reduce, maximum level of optimization (L=10)
-        self.iparm[5 ] = 0   # set to 1 if overwrite_b
-        self.iparm[7 ] = 2   # default 2-steps refinement
-        self.iparm[9 ] = 13  # set to 8 if symmetric
-        self.iparm[10] = 1   # set to 0 if symmetric
-        self.iparm[11] = 0   # Ax=b, no transpose
-        self.iparm[12] = 1   # enable matching for nonsymmetric
-        self.iparm[17] = 0   # disable nnz report
-        self.iparm[20] = 1   # default pivoting
-        self.iparm[23] = 0   # cannot use 10, idk why
-        self.iparm[34] = 1   # zero-based indexing
-        self.iparm[36] = 0   # CSR format
+        # https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-fortran/2025-2/pardiso.html
+        self.set_iparm(1 , 1  ) # manually setting
+        self.set_iparm(2 , 103) # OMP version of fill-in reduce, maximum level of optimization (L=10)
+        self.set_iparm(6 , 0  ) # set to 1 if overwrite_b
+        self.set_iparm(8 , 2  ) # default 2-steps refinement
+        self.set_iparm(10, 13 ) # set to 8 if symmetric
+        self.set_iparm(11, 1  ) # set to 0 if symmetric
+        self.set_iparm(12, 0  ) # Ax=b, no transpose
+        self.set_iparm(13, 1  ) # enable matching for nonsymmetric
+        self.set_iparm(18, 0  ) # disable nnz report
+        self.set_iparm(21, 1  ) # default pivoting
+        self.set_iparm(24, 0  ) # cannot use 10, idk why
+        self.set_iparm(35, 1  ) # zero-based indexing
+        self.set_iparm(37, 0  ) # CSR format
 
     def factorize(self, A):
         """
@@ -291,7 +291,7 @@ class PyPardisoSolver:
         ia = A.indptr
         ja = A.indices
 
-        if self.iparm[34] == 0:
+        if self.get_iparm(35) == 0:
             # 1-based indexing
             ia = ia + 1
             ja = ja + 1

--- a/pypardiso/pardiso_wrapper.py
+++ b/pypardiso/pardiso_wrapper.py
@@ -145,7 +145,7 @@ class PyPardisoSolver:
         self._init_iparm() # manually setup iparm
 
     def _init_iparm(self):
-        # https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-fortran/2025-2/pardiso.html
+        # https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-fortran/2025-2/pardiso-iparm-parameter.html
         self.set_iparm(1 , 1  ) # manually setting
         self.set_iparm(2 , 103) # OMP version of fill-in reduce, maximum level of optimization (L=10)
         self.set_iparm(6 , 0  ) # set to 1 if overwrite_b
@@ -181,7 +181,7 @@ class PyPardisoSolver:
         b = np.zeros((A.shape[0], 1))
         self._call_pardiso(A, b)
 
-    def solve(self, A, b):
+    def solve(self, A, b, overwrite_b: bool=False):
         """
         solve Ax=b for x
 
@@ -196,14 +196,24 @@ class PyPardisoSolver:
         """
 
         self._check_A(A)
-        b = self._check_b(A, b)
+        b_fcontig = self._check_b(A, b)
+
+        iparm6 = self.get_iparm(6)
+        if not(b_fcontig is b):
+            if overwrite_b:
+                warnings.warn('overwrite_b takes no effect: input b is not f_contiguous or the dtype is not compatible',
+                               SparseEfficiencyWarning)
+            overwrite_b = True # already made a copy of b, safe to overwrite
+
+        if overwrite_b:
+            self.set_iparm(6, 1) # overwrite
 
         if self._is_already_factorized(A):
             self.set_phase(33)
         else:
             self.set_phase(13)
 
-        x = self._call_pardiso(A, b)
+        x = self._call_pardiso(A, b_fcontig, overwrite_b=overwrite_b)
 
         # it is possible to call the solver with empty columns, but computationally expensive to check this
         # beforehand, therefore only the result is checked for infinite elements.
@@ -211,6 +221,7 @@ class PyPardisoSolver:
         #    warnings.warn('The result contains infinite elements. Make sure that matrix A contains no empty columns.',
         #                  PyPardisoWarning)
         # --> this check doesn't work consistently, maybe add an advanced input check method for A
+        self.set_iparm(6, iparm6) # revert
 
         return x
 
@@ -281,9 +292,10 @@ class PyPardisoSolver:
 
         return b
 
-    def _call_pardiso(self, A, b):
+    def _call_pardiso(self, A, b, overwrite_b: bool=False):
 
-        x = np.zeros_like(b)
+        # PARDISO will fill x with 0 if iparm(6)=1
+        x = np.empty_like(b) if overwrite_b else np.zeros_like(b)
         pardiso_error = ctypes.c_int32(0)
         c_int32_p = ctypes.POINTER(ctypes.c_int32)
         c_float64_p = ctypes.POINTER(ctypes.c_double)
@@ -316,7 +328,7 @@ class PyPardisoSolver:
         if pardiso_error.value != 0:
             raise PyPardisoError(pardiso_error.value)
         else:
-            return np.ascontiguousarray(x)  # change memory-layout back from fortran to c order
+            return b if overwrite_b else x # no need to force c_contiguous return
 
     def get_iparms(self):
         """Returns a dictionary of iparms"""

--- a/pypardiso/scipy_aliases.py
+++ b/pypardiso/scipy_aliases.py
@@ -9,7 +9,7 @@ from .pardiso_wrapper import PyPardisoSolver
 pypardiso_solver = PyPardisoSolver()
 
 
-def spsolve(A, b, factorize=True, squeeze=True, solver=pypardiso_solver, *args, **kwargs):
+def spsolve(A, b, factorize=True, squeeze=True, solver=pypardiso_solver, overwrite_b: bool=False, *args, **kwargs):
     """
     This function mimics scipy.sparse.linalg.spsolve, but uses the Pardiso solver instead of SuperLU/UMFPACK
 
@@ -45,7 +45,7 @@ def spsolve(A, b, factorize=True, squeeze=True, solver=pypardiso_solver, *args, 
     if factorize and not solver._is_already_factorized(A):
         solver.factorize(A)
 
-    x = solver.solve(A, b)
+    x = solver.solve(A, b, overwrite_b=overwrite_b)
 
     if squeeze:
         return x.squeeze()  # scipy spsolve always returns vectors with shape (n,) indstead of (n,1)


### PR DESCRIPTION
1. Manually set the iparm so that:
    * `iparm(2)=103` to use an OMP version of fill-in reduce algorithm with `L=10` optimization
    * `iparm(6)=0 or 1` depends on overwrite b or not
    * `iparm(35)=1` to use 0-based indexing, hence no need to add 1 for `ia` and `ja`

2. Support `overwrite_b` parameter:
    * if `b` got an implicit copy in `_check_b()` (`c_contiguous` -> `f_contiguous` or `b` is not contiguous), or `overwrite_b=True` is explicitly provided by the user, however currently the ans array still need to be allocated (I change it to `np.empty_like(b)` to avoid a 0-fill overhead) because PARDISO will try to overwrite `x` with 0 if `iparm(6)=1`
    * removed `return np.ascontiguousarray(x)` in `_call_pardiso()`, in case user can benefit from keeping `f_contiguous` with `overwrite_b=True` or multiplicate ccontig matrix with fcontig matrix, etc.
 

3. pytest result: 1 failed, 23 passed. There is a "ValueError: scipy.sparse does not support dtype float16." I guess it is not from my changes?